### PR TITLE
Allow specifying errors in expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This sets an expectation that a call will be made to the `query` function of the
 `params` - An optional array of parameters which will be matched against those passed to the
 `query` function
 
-`returns` - An optional array of "rows" to be returned by the `query` call.
+`returns` - An optional array or an Error instance. If an array, it will represent the "rows" to be returned by the `query` call. If an Error, the associated query will fail with this error. By default, an empty rowset is returned.
 
 Returns the parameters used on the call as an objects.  Handy for re-using the values later in the test:
 ```

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ class Client {
     if (nextExpectation.params && !arraysAreEqual(params, nextExpectation.params)) {
       return handleReturn(new Error(`Unexpected params for query "${sql}".\nExpected ${JSON.stringify(nextExpectation.params)}, got ${JSON.stringify(params)}.`), null, cb)
     }
-    return handleReturn(null, nextExpectation.returns, cb)
+    return handleReturn(nextExpectation.throws, nextExpectation.returns, cb)
   }
 
   // mock configuration
@@ -137,7 +137,16 @@ class Client {
     if (params && !Array.isArray(params)) {
       throw new Error(`Unexpected params: ${JSON.stringify(params)}.  Should be an array.`)
     }
-    this._expectations.push({ sql, params, returns: copyArray(returns) })
+
+    let throws = null
+    if (returns instanceof Error) {
+      throws = returns
+      returns = undefined
+    } else {
+      returns = copyArray(returns)
+    }
+
+    this._expectations.push({ sql, params, returns, throws })
     return this.expectations[this.expectations.length - 1]
   }
 


### PR DESCRIPTION
I'm looking to test the Clinic data server when a duplicate key error
happens.

With this patch:
 - If you pass in an array of rows, those will be returned in the second argument to the callback.
 - If you pass in an Error instance, that will be returned in the first argument to the callback.

I'm not super confident about overloading `.expect()`'s third param, happy to change to `expect(query, params, rows, err)` or something if preferred.