### PR TITLE
Return Client instance from `Pool#connect`

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,10 @@ class Client {
     return handleReturn(null, nextExpectation.returns, cb)
   }
 
+  // Used to release a client back to the pool; doesn't do anything here since no-gres has a single client per pool.
+  release () {
+  }
+
   // mock configuration
 
   errorOnConnect (err) {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,14 @@ class Pool {
   }
 
   connect (cb) {
-    return this._client.connect(cb)
+    if (cb) {
+      return this._client.connect((err) => {
+        if (err) cb(err)
+        else cb(null, this._client)
+      })
+    } else {
+      return this._client.connect().then(() => this._client)
+    }
   }
 
   query (sql, params, cb) {

--- a/test/index.js
+++ b/test/index.js
@@ -315,11 +315,37 @@ describe('client', async () => {
 
 describe('pool', async () => {
   describe('connect', () => {
+    it('connects with the underlying client: callback', { plan: 3 }, () => {
+      const pool = new NoGres.Pool()
+      pool.connect((err, client) => {
+        expect(err).to.be.null()
+        expect(client).to.equal(pool.client)
+        expect(pool.client.isConnected).to.be.true()
+      })
+    })
+
     it('connects with the underlying client', { plan: 2 }, async () => {
       const pool = new NoGres.Pool()
-      const err = await pool.connect()
-      expect(err).to.be.null()
+      const client = await pool.connect()
+      expect(client).to.equal(pool.client)
       expect(pool.client.isConnected).to.be.true()
+    })
+
+    it('passes through underlying client error: callback', { plan: 3 }, () => {
+      const pool = new NoGres.Pool()
+      pool.client.errorOnConnect(new Error('bar'))
+      pool.connect((err, client) => {
+        expect(err).to.not.be.null()
+        expect(client).to.be.undefined()
+        expect(pool.client.isConnected).to.be.false()
+      })
+    })
+
+    it('passes through underlying client error', { plan: 2 }, async () => {
+      const pool = new NoGres.Pool()
+      pool.client.errorOnConnect(new Error('bar'))
+      await expect(pool.connect()).rejects(Error, 'bar')
+      expect(pool.client.isConnected).to.be.false()
     })
   })
   describe('query', async () => {


### PR DESCRIPTION
Like the pg module does: https://node-postgres.com/api/pool#pool-connect

pool.connect returns a Client, client.connect returns null.