### PR TITLE
Inherit Client from EventEmitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const EventEmitter = require('events')
+
 const arraysAreEqual = (arr1, arr2) => {
   // Handles nested arrays, but not objects
   if (!Array.isArray(arr1) || !Array.isArray(arr2)) {
@@ -81,8 +83,9 @@ class Pool {
   }
 }
 
-class Client {
+class Client extends EventEmitter {
   constructor () {
+    super()
     this._expectations = []
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -331,6 +331,18 @@ describe('client', async () => {
       client.done()
     })
   })
+
+  describe('events', () => {
+    it('can be used to manually simulate events', { plan: 2 }, async () => {
+      const client = new NoGres.Client()
+      await client.connect()
+      client.once('notification', ({ channel, payload }) => {
+        expect(channel).to.equal('sample')
+        expect(payload).to.equal('some string')
+      })
+      client.emit('notification', { channel: 'sample', payload: 'some string' })
+    })
+  })
 })
 
 describe('pool', async () => {


### PR DESCRIPTION
For the Clinic data server, I'm looking to mock `NOTIFY` queries/'notification' events.

The way I'm doing it is by expect()ing a NOTIFY and then emitting a
'notification' event by hand in the test. That requires that clients can
emit events, though :)

This seems more in the minimalist spirit of this module than parsing
NOTIFY queries and doing the emit in here.