### PR TITLE
Add Node v12 support

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    coverage: true,
+    threshold: 100,
+    globals: 'queueMicrotask' // ignoring for Node 12 with lab (not a test issue), remove when lab is replaced by tap
+}


### PR DESCRIPTION
Fixes failing tests on Node v12.

See issue #9 